### PR TITLE
Support GOBUILDCACHE_-prefixed AWS env vars to prevent env leakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,15 @@ You'll also have to provide AWS credentials. `gobuildcache` embeds the AWS V2 S3
 export GOCACHEPROG=gobuildcache
 export GOBUILDCACHE_BACKEND_TYPE=s3
 export GOBUILDCACHE_S3_BUCKET=$BUCKET_NAME
-export AWS_REGION=$BUCKET_REGION
-export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY
-export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+export GOBUILDCACHE_AWS_REGION=$BUCKET_REGION
+export GOBUILDCACHE_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY
+export GOBUILDCACHE_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+export GOBUILDCACHE_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN  # optional, for temporary credentials
 go build ./...
 go test ./...
 ```
 
-> **Note**: All configuration environment variables support both `GOBUILDCACHE_<KEY>` and `<KEY>` forms (e.g., both `GOBUILDCACHE_S3_BUCKET` and `S3_BUCKET` work). The prefixed version takes precedence if both are set. The prefixed form is recommended to avoid conflicts with other tools. If the prefixed variable is set to an empty string, it falls through to the unprefixed version (or default).
+> **Note**: All configuration environment variables support both `GOBUILDCACHE_<KEY>` and `<KEY>` forms (e.g., both `GOBUILDCACHE_S3_BUCKET` and `S3_BUCKET` work). The prefixed version takes precedence if both are set. The prefixed form is strongly recommended for AWS variables (`GOBUILDCACHE_AWS_REGION`, `GOBUILDCACHE_AWS_ACCESS_KEY_ID`, `GOBUILDCACHE_AWS_SECRET_ACCESS_KEY`, `GOBUILDCACHE_AWS_SESSION_TOKEN`) — by using the prefixed form instead of the standard `AWS_*` variables, you avoid those values being inherited by other processes in the same environment (e.g., test binaries spawned by `go test`). If the prefixed variable is set to an empty string, it falls through to the unprefixed version (or default).
 
 ### Using Google Cloud Storage (GCS)
 
@@ -287,6 +288,10 @@ All environment variables support both `GOBUILDCACHE_<KEY>` and `<KEY>` forms (e
 | `-debug` | `GOBUILDCACHE_DEBUG` | `false` | Enable debug logging |
 | `-stats` | `GOBUILDCACHE_PRINT_STATS` | `false` | Print cache statistics on exit |
 | `-read-only` | `GOBUILDCACHE_READ_ONLY` | `false` | Read-only mode: allow cache reads but skip writes |
+| (env var only) | `GOBUILDCACHE_AWS_REGION` | (none) | AWS region for S3 backend (falls back to `AWS_REGION`) |
+| (env var only) | `GOBUILDCACHE_AWS_ACCESS_KEY_ID` | (none) | AWS access key for S3 backend (falls back to `AWS_ACCESS_KEY_ID`) |
+| (env var only) | `GOBUILDCACHE_AWS_SECRET_ACCESS_KEY` | (none) | AWS secret key for S3 backend (falls back to `AWS_SECRET_ACCESS_KEY`) |
+| (env var only) | `GOBUILDCACHE_AWS_SESSION_TOKEN` | (none) | AWS session token for temporary credentials (falls back to `AWS_SESSION_TOKEN`) |
 
 
 # How it Works

--- a/env_test.go
+++ b/env_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -281,4 +282,117 @@ func TestGetEnvFloatWithPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveS3Config(t *testing.T) {
+	// Helper to clear all AWS env vars for a test.
+	clearAWSEnv := func(t *testing.T) {
+		t.Helper()
+		for _, key := range []string{
+			"AWS_REGION", "GOBUILDCACHE_AWS_REGION",
+			"AWS_ACCESS_KEY_ID", "GOBUILDCACHE_AWS_ACCESS_KEY_ID",
+			"AWS_SECRET_ACCESS_KEY", "GOBUILDCACHE_AWS_SECRET_ACCESS_KEY",
+			"AWS_SESSION_TOKEN", "GOBUILDCACHE_AWS_SESSION_TOKEN",
+		} {
+			t.Setenv(key, "")
+		}
+	}
+
+	t.Run("returns empty config when no env vars set", func(t *testing.T) {
+		clearAWSEnv(t)
+		cfg, err := resolveS3Config()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Region != "" || cfg.AccessKeyID != "" || cfg.SecretAccessKey != "" || cfg.SessionToken != "" {
+			t.Errorf("expected empty config, got %+v", cfg)
+		}
+	})
+
+	t.Run("prefixed env vars take precedence", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("AWS_REGION", "us-east-1")
+		t.Setenv("GOBUILDCACHE_AWS_REGION", "us-west-2")
+		t.Setenv("AWS_ACCESS_KEY_ID", "old-key")
+		t.Setenv("GOBUILDCACHE_AWS_ACCESS_KEY_ID", "new-key")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "old-secret")
+		t.Setenv("GOBUILDCACHE_AWS_SECRET_ACCESS_KEY", "new-secret")
+		t.Setenv("AWS_SESSION_TOKEN", "old-token")
+		t.Setenv("GOBUILDCACHE_AWS_SESSION_TOKEN", "new-token")
+
+		cfg, err := resolveS3Config()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Region != "us-west-2" {
+			t.Errorf("Region = %q, want %q", cfg.Region, "us-west-2")
+		}
+		if cfg.AccessKeyID != "new-key" {
+			t.Errorf("AccessKeyID = %q, want %q", cfg.AccessKeyID, "new-key")
+		}
+		if cfg.SecretAccessKey != "new-secret" {
+			t.Errorf("SecretAccessKey = %q, want %q", cfg.SecretAccessKey, "new-secret")
+		}
+		if cfg.SessionToken != "new-token" {
+			t.Errorf("SessionToken = %q, want %q", cfg.SessionToken, "new-token")
+		}
+	})
+
+	t.Run("falls back to unprefixed env vars", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("AWS_REGION", "eu-west-1")
+		t.Setenv("AWS_ACCESS_KEY_ID", "fallback-key")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "fallback-secret")
+
+		cfg, err := resolveS3Config()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Region != "eu-west-1" {
+			t.Errorf("Region = %q, want %q", cfg.Region, "eu-west-1")
+		}
+		if cfg.AccessKeyID != "fallback-key" {
+			t.Errorf("AccessKeyID = %q, want %q", cfg.AccessKeyID, "fallback-key")
+		}
+	})
+
+	t.Run("errors when only access key is set", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("GOBUILDCACHE_AWS_ACCESS_KEY_ID", "some-key")
+
+		_, err := resolveS3Config()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "AWS_ACCESS_KEY_ID") {
+			t.Errorf("error should mention AWS_ACCESS_KEY_ID, got: %v", err)
+		}
+	})
+
+	t.Run("errors when only secret key is set", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("GOBUILDCACHE_AWS_SECRET_ACCESS_KEY", "some-secret")
+
+		_, err := resolveS3Config()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "AWS_SECRET_ACCESS_KEY") {
+			t.Errorf("error should mention AWS_SECRET_ACCESS_KEY, got: %v", err)
+		}
+	})
+
+	t.Run("session token is optional with full credentials", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("GOBUILDCACHE_AWS_ACCESS_KEY_ID", "key")
+		t.Setenv("GOBUILDCACHE_AWS_SECRET_ACCESS_KEY", "secret")
+
+		cfg, err := resolveS3Config()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.SessionToken != "" {
+			t.Errorf("SessionToken = %q, want empty", cfg.SessionToken)
+		}
+	})
 }

--- a/main.go
+++ b/main.go
@@ -397,7 +397,11 @@ func createBackend() (backends.Backend, error) {
 			return nil, fmt.Errorf("S3 bucket is required for S3 backend (set via -s3-bucket flag or S3_BUCKET env var)")
 		}
 
-		backend, err = backends.NewS3(s3Bucket, s3Prefix)
+		awsCfg, cfgErr := resolveS3Config()
+		if cfgErr != nil {
+			return nil, cfgErr
+		}
+		backend, err = backends.NewS3(s3Bucket, s3Prefix, awsCfg)
 
 	case "gcs":
 		if gcsBucket == "" {
@@ -442,6 +446,31 @@ func createBackend() (backends.Backend, error) {
 	}
 
 	return backend, nil
+}
+
+// resolveS3Config reads AWS configuration from environment variables using the
+// GOBUILDCACHE_ prefix convention, falling back to standard AWS env vars.
+// Using GOBUILDCACHE_-prefixed vars (e.g., GOBUILDCACHE_AWS_REGION instead of
+// AWS_REGION) allows users to provide AWS config to gobuildcache without those
+// values being inherited by other processes in the same environment, such as
+// test binaries spawned by go test.
+func resolveS3Config() (backends.S3Config, error) {
+	cfg := backends.S3Config{
+		Region:          getEnvWithPrefix("AWS_REGION", ""),
+		AccessKeyID:     getEnvWithPrefix("AWS_ACCESS_KEY_ID", ""),
+		SecretAccessKey: getEnvWithPrefix("AWS_SECRET_ACCESS_KEY", ""),
+		SessionToken:    getEnvWithPrefix("AWS_SESSION_TOKEN", ""),
+	}
+
+	// Validate that credentials are either both set or both unset.
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey == "" {
+		return backends.S3Config{}, fmt.Errorf("GOBUILDCACHE_AWS_ACCESS_KEY_ID (or AWS_ACCESS_KEY_ID) is set but GOBUILDCACHE_AWS_SECRET_ACCESS_KEY (or AWS_SECRET_ACCESS_KEY) is not; both must be provided together")
+	}
+	if cfg.AccessKeyID == "" && cfg.SecretAccessKey != "" {
+		return backends.S3Config{}, fmt.Errorf("GOBUILDCACHE_AWS_SECRET_ACCESS_KEY (or AWS_SECRET_ACCESS_KEY) is set but GOBUILDCACHE_AWS_ACCESS_KEY_ID (or AWS_ACCESS_KEY_ID) is not; both must be provided together")
+	}
+
+	return cfg, nil
 }
 
 func createLockingGroup() (locking.Group, error) {

--- a/pkg/backends/s3.go
+++ b/pkg/backends/s3.go
@@ -11,9 +11,22 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
+
+// S3Config holds AWS-specific configuration for the S3 backend.
+// These are resolved from environment variables in main.go using the
+// GOBUILDCACHE_-prefixed convention, allowing users to provide AWS
+// credentials without polluting the environment for other processes
+// (e.g., test binaries spawned by go test).
+type S3Config struct {
+	Region          string
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
 
 // S3 implements Backend using AWS S3.
 // This backend only handles S3 operations; local disk caching is handled by server.go.
@@ -28,11 +41,23 @@ type S3 struct {
 // NewS3 creates a new S3-based cache backend.
 // bucket is the S3 bucket name where cache files will be stored.
 // prefix is an optional prefix for all S3 keys (e.g., "cache/" or "").
-func NewS3(bucket, prefix string) (*S3, error) {
+// awsCfg provides explicit AWS configuration (region, credentials) resolved by the caller.
+func NewS3(bucket, prefix string, awsCfg S3Config) (*S3, error) {
 	ctx := context.Background()
 
-	// Load AWS config from environment/credentials
-	cfg, err := config.LoadDefaultConfig(ctx)
+	var configOpts []func(*config.LoadOptions) error
+
+	if awsCfg.Region != "" {
+		configOpts = append(configOpts, config.WithRegion(awsCfg.Region))
+	}
+
+	if awsCfg.AccessKeyID != "" && awsCfg.SecretAccessKey != "" {
+		configOpts = append(configOpts, config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(awsCfg.AccessKeyID, awsCfg.SecretAccessKey, awsCfg.SessionToken),
+		))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, configOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}


### PR DESCRIPTION
## Summary

When gobuildcache is used as `GOCACHEPROG`, standard AWS env vars (`AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) set in the shell are inherited by all child processes, including test binaries spawned by `go test`. This causes issues when test code reads these vars and gets unexpected values — for example, SRG component tests seeing `AWS_REGION=us-west-2` from the build cache config rather than their expected value.

This PR adds support for `GOBUILDCACHE_`-prefixed AWS env vars, using the existing `getEnvWithPrefix` convention already established for all other gobuildcache configuration. Users can now set only the prefixed vars (e.g., `GOBUILDCACHE_AWS_REGION`), keeping standard `AWS_*` vars out of the environment entirely so other processes are unaffected.

### Changes

- **`pkg/backends/s3.go`**: `NewS3` now accepts an `S3Config` struct with region, access key, secret key, and session token. The backend no longer reads env vars directly — that responsibility stays in `main.go` with all other config resolution.
- **`main.go`**: Added `resolveS3Config()` using the existing `getEnvWithPrefix` helper. Includes validation that errors if only one of access key / secret key is set (catches misconfiguration instead of silently falling back to the default credential chain).
- **`env_test.go`**: Added `TestResolveS3Config` with 6 test cases covering prefix precedence, unprefixed fallback, partial credential errors, and optional session token.
- **`README.md`**: Updated S3 usage example and config table to document the new prefixed AWS vars including `GOBUILDCACHE_AWS_SESSION_TOKEN`.

### Why this is safe

- Fully backward-compatible: unprefixed `AWS_*` vars still work as fallbacks when `GOBUILDCACHE_*` vars aren't set.
- The `getEnvWithPrefix` convention is already established and well-tested for all other gobuildcache config vars — this just extends it to AWS vars.
- Partial credential misconfiguration (e.g., access key set but secret key missing) now returns a clear error instead of silently using a different credential source.
- Session token support (`GOBUILDCACHE_AWS_SESSION_TOKEN`) enables users with temporary credentials (STS AssumeRole, SSO) to use the prefixed env var flow.

## Test plan

- [x] `TestResolveS3Config` covers: empty config, prefix precedence, unprefixed fallback, partial credential errors (both directions), optional session token
- [x] All existing unit tests pass
- [x] Build passes
- [ ] Integration tests (require live S3/GCS credentials, verified manually or in CI)