### PR TITLE
feat: add S3 path-style addressing support

### DIFF
--- a/main.go
+++ b/main.go
@@ -460,6 +460,7 @@ func resolveS3Config() (backends.S3Config, error) {
 		AccessKeyID:     getEnvWithPrefix("AWS_ACCESS_KEY_ID", ""),
 		SecretAccessKey: getEnvWithPrefix("AWS_SECRET_ACCESS_KEY", ""),
 		SessionToken:    getEnvWithPrefix("AWS_SESSION_TOKEN", ""),
+		UsePathStyle:    getEnvBoolWithPrefix("AWS_S3_USE_PATH_STYLE", false),
 	}
 
 	// Validate that credentials are either both set or both unset.

--- a/pkg/backends/s3.go
+++ b/pkg/backends/s3.go
@@ -26,6 +26,7 @@ type S3Config struct {
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string
+	UsePathStyle    bool
 }
 
 // S3 implements Backend using AWS S3.
@@ -62,7 +63,11 @@ func NewS3(bucket, prefix string, awsCfg S3Config) (*S3, error) {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
-	client := s3.NewFromConfig(cfg)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if awsCfg.UsePathStyle {
+			o.UsePathStyle = true
+		}
+	})
 
 	backend := &S3{
 		client:    client,


### PR DESCRIPTION
## Summary

- Add `UsePathStyle` option to `S3Config` struct
- Controllable via `GOBUILDCACHE_AWS_S3_USE_PATH_STYLE=true` env var (or `AWS_S3_USE_PATH_STYLE`)
- When enabled, uses path-style S3 requests (`endpoint:port/bucket`) instead of virtual-hosted-style (`bucket.endpoint:port`)

## Motivation

S3-compatible backends like LocalStack and MinIO require path-style addressing. Without this option, `gobuildcache` fails with 500/403 errors when using a custom `AWS_ENDPOINT_URL` because the SDK tries to resolve `bucket-name.endpoint:port` which these backends can't handle.

Fixes #17

## Test plan
- [x] `go build ./...` passes
- [x] Tested manually with LocalStack (path-style works, cache hits confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)