### PR TITLE
feat: add support for S3-compatible storage with custom endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 builds/
 keys/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ go test ./...
 
 > **Note**: All configuration environment variables support both `GOBUILDCACHE_<KEY>` and `<KEY>` forms (e.g., both `GOBUILDCACHE_S3_BUCKET` and `S3_BUCKET` work). The prefixed version takes precedence if both are set. The prefixed form is strongly recommended for AWS variables (`GOBUILDCACHE_AWS_REGION`, `GOBUILDCACHE_AWS_ACCESS_KEY_ID`, `GOBUILDCACHE_AWS_SECRET_ACCESS_KEY`, `GOBUILDCACHE_AWS_SESSION_TOKEN`) — by using the prefixed form instead of the standard `AWS_*` variables, you avoid those values being inherited by other processes in the same environment (e.g., test binaries spawned by `go test`). If the prefixed variable is set to an empty string, it falls through to the unprefixed version (or default).
 
+#### Using S3-compatible storage (MinIO, Ceph, R2, etc.)
+
+`gobuildcache` can target any S3-compatible object store by setting `GOBUILDCACHE_S3_ENDPOINT` to the service's endpoint URL. Most non-AWS S3 implementations require path-style addressing, which you enable with `GOBUILDCACHE_AWS_S3_USE_PATH_STYLE=true`.
+
+```bash
+export GOCACHEPROG=gobuildcache
+export GOBUILDCACHE_BACKEND_TYPE=s3
+export GOBUILDCACHE_S3_BUCKET=$BUCKET_NAME
+export GOBUILDCACHE_S3_ENDPOINT=https://minio.internal:9000
+export GOBUILDCACHE_AWS_S3_USE_PATH_STYLE=true
+export GOBUILDCACHE_AWS_REGION=us-east-1
+export GOBUILDCACHE_AWS_ACCESS_KEY_ID=$ACCESS_KEY
+export GOBUILDCACHE_AWS_SECRET_ACCESS_KEY=$SECRET_KEY
+go build ./...
+go test ./...
+```
+
 ### Using Google Cloud Storage (GCS)
 
 ```bash
@@ -292,6 +309,8 @@ All environment variables support both `GOBUILDCACHE_<KEY>` and `<KEY>` forms (e
 | (env var only) | `GOBUILDCACHE_AWS_ACCESS_KEY_ID` | (none) | AWS access key for S3 backend (falls back to `AWS_ACCESS_KEY_ID`) |
 | (env var only) | `GOBUILDCACHE_AWS_SECRET_ACCESS_KEY` | (none) | AWS secret key for S3 backend (falls back to `AWS_SECRET_ACCESS_KEY`) |
 | (env var only) | `GOBUILDCACHE_AWS_SESSION_TOKEN` | (none) | AWS session token for temporary credentials (falls back to `AWS_SESSION_TOKEN`) |
+| (env var only) | `GOBUILDCACHE_S3_ENDPOINT` | (none) | Custom S3 endpoint URL for S3-compatible stores, e.g. MinIO (falls back to `S3_ENDPOINT`) |
+| (env var only) | `GOBUILDCACHE_AWS_S3_USE_PATH_STYLE` | `false` | Use path-style S3 addressing; usually required for S3-compatible stores (falls back to `AWS_S3_USE_PATH_STYLE`) |
 
 
 # How it Works

--- a/env_test.go
+++ b/env_test.go
@@ -293,6 +293,7 @@ func TestResolveS3Config(t *testing.T) {
 			"AWS_ACCESS_KEY_ID", "GOBUILDCACHE_AWS_ACCESS_KEY_ID",
 			"AWS_SECRET_ACCESS_KEY", "GOBUILDCACHE_AWS_SECRET_ACCESS_KEY",
 			"AWS_SESSION_TOKEN", "GOBUILDCACHE_AWS_SESSION_TOKEN",
+			"S3_ENDPOINT", "GOBUILDCACHE_S3_ENDPOINT",
 		} {
 			t.Setenv(key, "")
 		}
@@ -304,8 +305,48 @@ func TestResolveS3Config(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if cfg.Region != "" || cfg.AccessKeyID != "" || cfg.SecretAccessKey != "" || cfg.SessionToken != "" {
+		if cfg.Region != "" || cfg.AccessKeyID != "" || cfg.SecretAccessKey != "" || cfg.SessionToken != "" || cfg.Endpoint != "" {
 			t.Errorf("expected empty config, got %+v", cfg)
+		}
+	})
+
+	t.Run("resolves S3_ENDPOINT from prefixed env var", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("GOBUILDCACHE_S3_ENDPOINT", "https://minio.internal:9000")
+
+		cfg, err := resolveS3Config()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Endpoint != "https://minio.internal:9000" {
+			t.Errorf("Endpoint = %q, want %q", cfg.Endpoint, "https://minio.internal:9000")
+		}
+	})
+
+	t.Run("falls back to unprefixed S3_ENDPOINT", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("S3_ENDPOINT", "https://s3.example.com")
+
+		cfg, err := resolveS3Config()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Endpoint != "https://s3.example.com" {
+			t.Errorf("Endpoint = %q, want %q", cfg.Endpoint, "https://s3.example.com")
+		}
+	})
+
+	t.Run("prefixed S3_ENDPOINT takes precedence over unprefixed", func(t *testing.T) {
+		clearAWSEnv(t)
+		t.Setenv("S3_ENDPOINT", "https://unprefixed.example.com")
+		t.Setenv("GOBUILDCACHE_S3_ENDPOINT", "https://prefixed.example.com")
+
+		cfg, err := resolveS3Config()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Endpoint != "https://prefixed.example.com" {
+			t.Errorf("Endpoint = %q, want %q", cfg.Endpoint, "https://prefixed.example.com")
 		}
 	})
 

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func runServerCommand() {
 		fmt.Fprintf(os.Stderr, "  CACHE_DIR        Local cache directory\n")
 		fmt.Fprintf(os.Stderr, "  S3_BUCKET        S3 bucket name\n")
 		fmt.Fprintf(os.Stderr, "  S3_PREFIX        S3 key prefix\n")
+		fmt.Fprintf(os.Stderr, "  S3_ENDPOINT      Custom S3 endpoint URL (for S3-compatible stores)\n")
 		fmt.Fprintf(os.Stderr, "  GCS_BUCKET       GCS bucket name\n")
 		fmt.Fprintf(os.Stderr, "  GCS_PREFIX       GCS object prefix\n")
 		fmt.Fprintf(os.Stderr, "  COMPRESSION      Enable LZ4 compression (true/false)\n")
@@ -171,6 +172,7 @@ func runClearCommand() {
 		fmt.Fprintf(os.Stderr, "  CACHE_DIR      Local cache directory\n")
 		fmt.Fprintf(os.Stderr, "  S3_BUCKET      S3 bucket name\n")
 		fmt.Fprintf(os.Stderr, "  S3_PREFIX      S3 key prefix\n")
+		fmt.Fprintf(os.Stderr, "  S3_ENDPOINT    Custom S3 endpoint URL (for S3-compatible stores)\n")
 		fmt.Fprintf(os.Stderr, "  GCS_BUCKET     GCS bucket name\n")
 		fmt.Fprintf(os.Stderr, "  GCS_PREFIX     GCS object prefix\n")
 		fmt.Fprintf(os.Stderr, "  S3_TMP_DIR     Local temp directory for S3 backend\n")
@@ -263,6 +265,7 @@ func runClearRemoteCommand() {
 		fmt.Fprintf(os.Stderr, "  BACKEND_TYPE   Backend type (disk, s3, gcs)\n")
 		fmt.Fprintf(os.Stderr, "  S3_BUCKET      S3 bucket name\n")
 		fmt.Fprintf(os.Stderr, "  S3_PREFIX      S3 key prefix\n")
+		fmt.Fprintf(os.Stderr, "  S3_ENDPOINT    Custom S3 endpoint URL (for S3-compatible stores)\n")
 		fmt.Fprintf(os.Stderr, "  GCS_BUCKET     GCS bucket name\n")
 		fmt.Fprintf(os.Stderr, "  GCS_PREFIX     GCS object prefix\n")
 		fmt.Fprintf(os.Stderr, "\nNote: Command-line flags take precedence over environment variables.\n")
@@ -461,6 +464,7 @@ func resolveS3Config() (backends.S3Config, error) {
 		SecretAccessKey: getEnvWithPrefix("AWS_SECRET_ACCESS_KEY", ""),
 		SessionToken:    getEnvWithPrefix("AWS_SESSION_TOKEN", ""),
 		UsePathStyle:    getEnvBoolWithPrefix("AWS_S3_USE_PATH_STYLE", false),
+		Endpoint:        getEnvWithPrefix("S3_ENDPOINT", ""),
 	}
 
 	// Validate that credentials are either both set or both unset.

--- a/pkg/backends/s3.go
+++ b/pkg/backends/s3.go
@@ -27,6 +27,10 @@ type S3Config struct {
 	SecretAccessKey string
 	SessionToken    string
 	UsePathStyle    bool
+	// Endpoint optionally overrides the S3 endpoint URL, allowing the use of
+	// S3-compatible object stores (e.g. MinIO, Ceph, Cloudflare R2). When empty,
+	// the AWS SDK resolves the standard AWS S3 endpoint from the region.
+	Endpoint string
 }
 
 // S3 implements Backend using AWS S3.
@@ -66,6 +70,9 @@ func NewS3(bucket, prefix string, awsCfg S3Config) (*S3, error) {
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		if awsCfg.UsePathStyle {
 			o.UsePathStyle = true
+		}
+		if awsCfg.Endpoint != "" {
+			o.BaseEndpoint = aws.String(awsCfg.Endpoint)
 		}
 	})
 


### PR DESCRIPTION
## Why

Today the S3 backend can only talk to AWS S3 — the endpoint is derived from the
configured region, so there's no way to point `gobuildcache` at a non-AWS
S3-compatible store (MinIO, Ceph/RADOS Gateway, Cloudflare R2, Backblaze B2,
self-hosted gateways, etc.).

These services speak the S3 API and are a natural fit for teams that:
- run CI outside AWS (GitHub-hosted runners, on-prem, other clouds) and want a
  low-latency cache close to their runners, and/or
- already operate an S3-compatible object store and don't want to add AWS S3
  just for the build cache.

This PR adds a single opt-in setting to target any S3-compatible endpoint, with
no change to existing AWS S3 behavior.

## What

- Add an optional `Endpoint` field to `S3Config` and wire it to the AWS SDK v2
  `o.BaseEndpoint` option in `NewS3` (the supported override mechanism; the
  deprecated `EndpointResolver` is avoided). When empty, the SDK resolves the
  standard AWS endpoint exactly as before.
- Resolve the endpoint from a new env var, following the existing
  prefixed/unprefixed convention (prefixed wins, empty prefixed value falls
  through): `GOBUILDCACHE_S3_ENDPOINT` / `S3_ENDPOINT`.
- Pair naturally with the existing `AWS_S3_USE_PATH_STYLE` toggle, which most
  S3-compatible servers require. Path-style stays a separate, explicit setting —
  setting an endpoint does **not** silently change addressing behavior.
- Docs: new "Using S3-compatible storage" section in the README with a MinIO
  example, plus config-table entries for `S3_ENDPOINT` and the (previously
  undocumented) `AWS_S3_USE_PATH_STYLE`. Also listed in the `server`, `clear`,
  and `clear-remote` `-help` output.

## Usage

```bash
export GOCACHEPROG=gobuildcache
export GOBUILDCACHE_BACKEND_TYPE=s3
export GOBUILDCACHE_S3_BUCKET=$BUCKET_NAME
export GOBUILDCACHE_S3_ENDPOINT=https://minio.internal:9000
export GOBUILDCACHE_AWS_S3_USE_PATH_STYLE=true
export GOBUILDCACHE_AWS_REGION=us-east-1
export GOBUILDCACHE_AWS_ACCESS_KEY_ID=$ACCESS_KEY
export GOBUILDCACHE_AWS_SECRET_ACCESS_KEY=$SECRET_KEY
go build ./...
